### PR TITLE
[SWYP-102] naver search api를 사용하여 트랜드 검색 구현 

### DIFF
--- a/src/main/java/com/bizket/auth/config/SecurityConstant.java
+++ b/src/main/java/com/bizket/auth/config/SecurityConstant.java
@@ -9,6 +9,7 @@ public final class SecurityConstant {
         "/auth/instagram/**",
         "/login/callback",
         "/trends/**",
+        "/datalab/trends/**",
         "/marketing/contents",
         "/marketing/contents/*",
         "/docs/index.html"

--- a/src/main/java/com/bizket/datalab/config/DatalabRestTemplateConfig.java
+++ b/src/main/java/com/bizket/datalab/config/DatalabRestTemplateConfig.java
@@ -1,0 +1,20 @@
+package com.bizket.datalab.config;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Duration;
+
+@Configuration
+public class DatalabRestTemplateConfig {
+    @Bean("datalabRestTemplate")
+    public RestTemplate datalabRestTemplate(RestTemplateBuilder builder) {
+        return builder
+                .connectTimeout(Duration.ofSeconds(5))
+                .readTimeout(Duration.ofSeconds(5))
+                .build();
+    }
+}
+

--- a/src/main/java/com/bizket/datalab/controller/NaverTrendController.java
+++ b/src/main/java/com/bizket/datalab/controller/NaverTrendController.java
@@ -1,0 +1,108 @@
+package com.bizket.datalab.controller;
+
+import com.bizket.datalab.dto.forecastInterest.ForecastInterestResponseDto;
+import com.bizket.datalab.dto.monthlyInterest.MonthlyInterestResponseDto;
+import com.bizket.datalab.dto.relatedInterest.RelatedSuggestDto;
+import com.bizket.datalab.service.NaverTrendService;
+import com.bizket.trend.dto.Saturation;
+import org.springframework.web.bind.annotation.*;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 1. 월별 관심도 반환 ( 최근 6개월 )
+ * 2. 키워드 탑10 추천 키워드
+ * 3. 블로그 전체 검색량, 뉴스 전체 검색량 ( 카페는 네이버 oauth로그인 구현 필수라 집계 불가 )
+ * 4. 블로그, 뉴스 키워드에 따른 검색 포화도
+ * 5. 다음달 검색 비율 예측 ( 최근 6개월 )
+ */
+
+@RestController
+@RequestMapping("/datalab/trends")
+public class NaverTrendController {
+
+    private final NaverTrendService service;
+
+    public NaverTrendController(NaverTrendService service) {
+        this.service = service;
+    }
+
+    // 월 별 관심도 반환
+    // curl -s http://localhost:8080/datalab/trends/java/monthly | jq .
+    @GetMapping("/{keyword}/monthly")
+    public List<MonthlyInterestResponseDto> monthly(
+            @PathVariable String keyword,
+            @RequestParam(required = false) String start,
+            @RequestParam(required = false) String end
+    ) {
+        String defaultEnd   = LocalDate.now().toString();
+        String defaultStart = LocalDate.now().minusMonths(6).toString();
+        return service.getMonthlyTrends(
+                keyword,
+                start != null ? start : defaultStart,
+                end   != null ? end   : defaultEnd
+        );
+    }
+
+    // 탑10 추천 키워드
+    // curl -s "http://localhost:8080/datalab/trends/자바/related" | jq .
+    @GetMapping("/{keyword}/related")
+    public RelatedSuggestDto related(@PathVariable String keyword) {
+        return service.getRelatedSuggestions(keyword);
+    }
+
+    // 블로그 전체 검색량
+    // curl -s http://localhost:8080/datalab/trends/java/blog/total | jq .
+    @GetMapping("/{kw}/blog/total")
+    public Map<String,Object> blogTotal(@PathVariable("kw") String kw) {
+        long total = service.fetchBlogTotalCount(kw);
+        return Map.of("keyword", kw, "blogTotalCount", total);
+    }
+
+    // 뉴스 전체 검색량
+    // curl -s http://localhost:8080/datalab/trends/java/news/total | jq .
+    @GetMapping("/{kw}/news/total")
+    public Map<String,Object> newsTotal(@PathVariable("kw") String kw) {
+        long total = service.fetchNewsTotalCount(kw);
+        return Map.of("keyword", kw, "newsTotalCount", total);
+    }
+
+    // 블로그 포화지수
+    // curl -s http://localhost:8080/datalab/trends/java/saturation-blog | jq .
+    @GetMapping("/{kw}/saturation-blog")
+    public Saturation satBlog(@PathVariable("kw") String kw) {
+        return service.calculateBlogSaturation(kw);
+    }
+
+    // 뉴스 포화지수
+    // curl -s http://localhost:8080/datalab/trends/java/saturation-news | jq .
+    @GetMapping("/{kw}/saturation-news")
+    public Saturation satNews(@PathVariable("kw") String kw) {
+        return service.calculateNewsSaturation(kw);
+    }
+
+    // 다음 달 관심도 비율 예측
+    // curl -s "http://localhost:8080/datalab/trends/java/forecast" | jq .
+    // 직접 기간 지정 : curl -s "http://localhost:8080/datalab/trends/java/forecast?start=2024-01-01&end=2024-07-31" | jq .
+    @GetMapping("/{kw}/forecast")
+    public ForecastInterestResponseDto forecast(
+            @PathVariable String kw,
+            @RequestParam(required = false) String start,
+            @RequestParam(required = false) String end
+    ) {
+        LocalDate today     = LocalDate.now();
+        LocalDate lastMonth         = today.minusMonths(1);
+        LocalDate defaultEndDate    = lastMonth.withDayOfMonth(lastMonth.lengthOfMonth());
+        LocalDate defaultStartDate  = defaultEndDate.minusMonths(5).withDayOfMonth(1);
+
+        String defaultStart = defaultStartDate.toString();
+        String defaultEnd   = defaultEndDate.toString();
+
+        return service.forecastNextMonthInterest(
+                kw,
+                start != null ? start : defaultStart,
+                end   != null ? end   : defaultEnd
+        );
+    }
+}

--- a/src/main/java/com/bizket/datalab/dto/forecastInterest/ForecastInterestResponseDto.java
+++ b/src/main/java/com/bizket/datalab/dto/forecastInterest/ForecastInterestResponseDto.java
@@ -1,0 +1,9 @@
+package com.bizket.datalab.dto.forecastInterest;
+
+import java.time.YearMonth;
+
+public record ForecastInterestResponseDto(
+        String keyword,
+        YearMonth forecastMonth,
+        double forecastRatio
+) {}

--- a/src/main/java/com/bizket/datalab/dto/monthlyInterest/MonthlyInterestDataPointDto.java
+++ b/src/main/java/com/bizket/datalab/dto/monthlyInterest/MonthlyInterestDataPointDto.java
@@ -1,0 +1,6 @@
+package com.bizket.datalab.dto.monthlyInterest;
+
+public record MonthlyInterestDataPointDto(
+        String period,    // "2024-05" 같은 문자열
+        double ratio      // 0~100 사이 상대값
+) {}

--- a/src/main/java/com/bizket/datalab/dto/monthlyInterest/MonthlyInterestDto.java
+++ b/src/main/java/com/bizket/datalab/dto/monthlyInterest/MonthlyInterestDto.java
@@ -1,0 +1,7 @@
+package com.bizket.datalab.dto.monthlyInterest;
+
+import java.util.List;
+
+public record MonthlyInterestDto(
+        List<MonthlyInterestResultDto> results
+) {}

--- a/src/main/java/com/bizket/datalab/dto/monthlyInterest/MonthlyInterestResponseDto.java
+++ b/src/main/java/com/bizket/datalab/dto/monthlyInterest/MonthlyInterestResponseDto.java
@@ -1,0 +1,9 @@
+package com.bizket.datalab.dto.monthlyInterest;
+
+import java.time.YearMonth;
+
+public record MonthlyInterestResponseDto(
+        String keyword,
+        YearMonth yearMonth,
+        double searchVolume
+) {}

--- a/src/main/java/com/bizket/datalab/dto/monthlyInterest/MonthlyInterestResultDto.java
+++ b/src/main/java/com/bizket/datalab/dto/monthlyInterest/MonthlyInterestResultDto.java
@@ -1,0 +1,9 @@
+package com.bizket.datalab.dto.monthlyInterest;
+
+import java.util.List;
+
+public record MonthlyInterestResultDto(
+        String title,
+        List<String> keywords,
+        List<MonthlyInterestDataPointDto> data
+) {}

--- a/src/main/java/com/bizket/datalab/dto/relatedInterest/NaverACResponse.java
+++ b/src/main/java/com/bizket/datalab/dto/relatedInterest/NaverACResponse.java
@@ -1,0 +1,10 @@
+package com.bizket.datalab.dto.relatedInterest;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record NaverACResponse(
+        List<List<Object>> items
+) {}

--- a/src/main/java/com/bizket/datalab/dto/relatedInterest/RelatedSuggestDto.java
+++ b/src/main/java/com/bizket/datalab/dto/relatedInterest/RelatedSuggestDto.java
@@ -1,0 +1,8 @@
+package com.bizket.datalab.dto.relatedInterest;
+
+import java.util.List;
+
+public record RelatedSuggestDto(
+        String keyword,
+        List<String> suggestions
+) {}

--- a/src/main/java/com/bizket/datalab/dto/totalSearch/TotalSearchResponseDto.java
+++ b/src/main/java/com/bizket/datalab/dto/totalSearch/TotalSearchResponseDto.java
@@ -1,0 +1,6 @@
+package com.bizket.datalab.dto.totalSearch;
+
+public record TotalSearchResponseDto(
+        String keyword,
+        long totalCount
+) {}

--- a/src/main/java/com/bizket/datalab/service/NaverTrendService.java
+++ b/src/main/java/com/bizket/datalab/service/NaverTrendService.java
@@ -1,0 +1,216 @@
+package com.bizket.datalab.service;
+
+import com.bizket.datalab.dto.forecastInterest.ForecastInterestResponseDto;
+import com.bizket.datalab.dto.monthlyInterest.MonthlyInterestResponseDto;
+import com.bizket.datalab.dto.monthlyInterest.MonthlyInterestDto;
+import com.bizket.datalab.dto.relatedInterest.NaverACResponse;
+import com.bizket.datalab.dto.relatedInterest.RelatedSuggestDto;
+import com.bizket.datalab.dto.totalSearch.TotalSearchResponseDto;
+import com.bizket.trend.dto.Saturation;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+public class NaverTrendService {
+
+    private static final String API_URL = "https://openapi.naver.com/v1/datalab/search";
+    private static final String AC_URL = "https://ac.search.naver.com/nx/ac";
+    private static final String BLOG_API = "https://openapi.naver.com/v1/search/blog.json";
+    private static final String NEWS_API = "https://openapi.naver.com/v1/search/news.json";
+
+    private final RestTemplate acRest = new RestTemplate();
+    private final RestTemplate rt;
+    private final String clientId;
+    private final String clientSecret;
+
+    public NaverTrendService(
+            @Qualifier("datalabRestTemplate") RestTemplate rt,
+            @Value("${naver.client.id}") String clientId,
+            @Value("${naver.client.secret}") String clientSecret
+    ) {
+        this.rt = rt;
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+    }
+
+    // 월별 관심사 반환 - 검색 절대량 반환 불가
+    public List<MonthlyInterestResponseDto> getMonthlyTrends(String keyword, String startDate, String endDate) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("X-Naver-Client-Id",     clientId);
+        headers.set("X-Naver-Client-Secret", clientSecret);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        Map<String,Object> body = Map.of(
+                "startDate", startDate,
+                "endDate",   endDate,
+                "timeUnit",  "month",
+                "keywordGroups", List.of(
+                        Map.of(
+                                "groupName", keyword,
+                                "keywords",  List.of(keyword)
+                        )
+                )
+        );
+
+        HttpEntity<Map<String,Object>> req = new HttpEntity<>(body, headers);
+        ResponseEntity<MonthlyInterestDto> resp = rt.exchange(API_URL, HttpMethod.POST, req, MonthlyInterestDto.class);
+
+        var result = resp.getBody().results().get(0);
+        return result.data().stream()
+                .map(dp -> {
+                    LocalDate date = LocalDate.parse(dp.period());
+                    YearMonth ym = YearMonth.from(date);
+                    return new MonthlyInterestResponseDto(
+                            keyword,
+                            ym,
+                            dp.ratio()
+                    );
+                })
+                .collect(Collectors.toList());
+    }
+
+
+    // 자동완성 API 기반 연관검색어 Top10 조회
+    public RelatedSuggestDto getRelatedSuggestions(String keyword) {
+        String url = UriComponentsBuilder
+                .fromUriString(AC_URL)
+                .queryParam("q",        keyword)
+                .queryParam("con",      "2")
+                .queryParam("frm",      "nx")
+                .queryParam("ans",      "2")
+                .queryParam("r_format", "json")
+                .queryParam("r_enc",    "UTF-8")
+                .queryParam("q_enc",    "UTF-8")
+                .queryParam("rev",      "4")
+                .queryParam("st",       "100")
+                .build()
+                .toUriString();
+
+        NaverACResponse resp = acRest.getForObject(url, NaverACResponse.class);
+        if (resp == null || resp.items() == null || resp.items().isEmpty()) {
+            return new RelatedSuggestDto(keyword, List.of());
+        }
+
+        Object first = resp.items().get(0);
+        if (!(first instanceof List<?> rawList)) {
+            return new RelatedSuggestDto(keyword, List.of());
+        }
+
+        List<String> suggestions = rawList.stream()
+                .filter(e -> e instanceof List<?>)
+                .map(e -> (List<?>) e)
+                .map(list -> list.isEmpty() ? "" : list.get(0).toString())
+                .limit(10)
+                .collect(Collectors.toList());
+
+        return new RelatedSuggestDto(keyword, suggestions);
+    }
+
+
+    // 블로그 전체 검색량 조회
+    public long fetchBlogTotalCount(String keyword) {
+        return fetchTotalCount(BLOG_API, keyword);
+    }
+
+    // 뉴스 전체 검색량 조회
+    public long fetchNewsTotalCount(String keyword) {
+        return fetchTotalCount(NEWS_API, keyword);
+    }
+
+    // 공통 로직: display=1 로 total 만 가져오기
+    private long fetchTotalCount(String apiUrl, String keyword) {
+        String url = UriComponentsBuilder
+                .fromUriString(apiUrl)
+                .queryParam("query",   keyword)
+                .queryParam("display", 1)
+                .toUriString();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("X-Naver-Client-Id",     clientId);
+        headers.set("X-Naver-Client-Secret", clientSecret);
+        HttpEntity<Void> req = new HttpEntity<>(headers);
+
+        @SuppressWarnings("unchecked")
+        Map<String,Object> body = rt.exchange(url, HttpMethod.GET, req, Map.class).getBody();
+        Object total = body.get("total");
+        return total instanceof Number
+                ? ((Number) total).longValue()
+                : Long.parseLong(total.toString());
+    }
+
+    // 블로그 기반 포화지수 (블로그 글 수 / 전체 웹문서 검색량)
+    public Saturation calculateBlogSaturation(String keyword) {
+        long contentCount = fetchBlogTotalCount(keyword);
+        long searchCount  = fetchWebTotalCount(keyword);  // webkr.json total
+        double index = searchCount > 0
+                ? contentCount * 100.0 / searchCount
+                : 0;
+        return new Saturation(keyword, contentCount, searchCount, index);
+    }
+
+    // 뉴스 기반 포화지수 (뉴스 기사 수 / 전체 웹문서 검색량)
+    public Saturation calculateNewsSaturation(String keyword) {
+        long contentCount = fetchNewsTotalCount(keyword);
+        long searchCount  = fetchWebTotalCount(keyword);
+        double index = searchCount > 0
+                ? contentCount * 100.0 / searchCount
+                : 0;
+        return new Saturation(keyword, contentCount, searchCount, index);
+    }
+
+    // 전체 웹문서 검색량 조회
+    public long fetchWebTotalCount(String keyword) {
+        return fetchTotalCount("https://openapi.naver.com/v1/search/webkr.json", keyword);
+    }
+
+    //다음 달 관심도 비율 예측
+    public ForecastInterestResponseDto forecastNextMonthInterest(
+            String keyword,
+            String startDate,
+            String endDate
+    ) {
+        List<MonthlyInterestResponseDto> history =
+                getMonthlyTrends(keyword, startDate, endDate);
+
+        int n = history.size();
+        YearMonth nextYm;
+        double forecastRatio;
+
+        if (n < 2) {
+            YearMonth lastYm = (n == 0)
+                    ? YearMonth.parse(endDate.substring(0, 7))
+                    : history.get(n - 1).yearMonth();
+            double lastRatio = (n == 0)
+                    ? 0.0
+                    : history.get(n - 1).searchVolume();
+
+            nextYm         = lastYm.plusMonths(1);
+            forecastRatio  = lastRatio;
+        } else {
+            double sumDelta = 0;
+            for (int i = 1; i < n; i++) {
+                sumDelta += history.get(i).searchVolume()
+                        - history.get(i - 1).searchVolume();
+            }
+            double avgDelta = sumDelta / (n - 1);
+            MonthlyInterestResponseDto last = history.get(n - 1);
+            nextYm         = last.yearMonth().plusMonths(1);
+            forecastRatio  = Math.max(last.searchVolume() + avgDelta, 0);
+        }
+
+        return new ForecastInterestResponseDto(
+                keyword,
+                nextYm,
+                forecastRatio
+        );
+    }
+}

--- a/src/main/java/com/bizket/insight/RestTemplateConfig.java
+++ b/src/main/java/com/bizket/insight/RestTemplateConfig.java
@@ -4,6 +4,7 @@ package com.bizket.insight;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.web.client.RestTemplate;
 
 import java.time.Duration;
@@ -11,6 +12,7 @@ import java.time.Duration;
 @Configuration
 public class RestTemplateConfig {
 
+    @Primary
     @Bean
     public RestTemplate restTemplate(RestTemplateBuilder builder) {
         return builder


### PR DESCRIPTION
구현한 목록은 아래와 같습니다.

 1. 월별 관심도 반환 ( 최근 6개월 )
 2. 키워드 탑10 추천 키워드
 3. 블로그 전체 검색량, 뉴스 전체 검색량 ( 카페는 네이버 oauth로그인 구현 필수라 집계 불가 )
 4. 블로그, 뉴스 키워드에 따른 검색 포화도
 5. 다음달 검색 비율 예측 ( 최근 6개월 )

curl -s http://localhost:8080/datalab/trends/java/monthly | jq .
<img width="1070" alt="image" src="https://github.com/user-attachments/assets/93ddd2cb-7646-4092-b922-809d57a054f9" />

curl -s "http://localhost:8080/datalab/trends/자바/related" | jq .
<img width="573" alt="image" src="https://github.com/user-attachments/assets/3f2f0d30-1a3d-438a-bb4d-f53eed47bc5c" />


...

네이버로 구현이 완료 된 이유로 파이썬 서버는 더이상 필요가 없어졌습니다.
해당 부분 시간 있을 때 빠르게 삭제하도록 하겠습니다.

